### PR TITLE
Add `onStartShouldSetPanResponder: () => true` so animation starts on…

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -28,7 +28,8 @@ class panresponder_demo extends Component {
 
   componentWillMount() {
     this._panResponder = PanResponder.create({
-      onMoveShouldSetResponderCapture: () => true,
+      onStartShouldSetPanResponder:       () => true,
+      onMoveShouldSetResponderCapture:    () => true,
       onMoveShouldSetPanResponderCapture: () => true,
 
       onPanResponderGrant: (e, gestureState) => {


### PR DESCRIPTION
… press down.

Without this, the user needs to start moving the object for the scale transform to occur. 

In my experience, pressing down on an object and having that object "pop out" of the page (via the scale transform) is a really nice indicator that we are now dragging the object. 

Adding `onStartShouldSetPanResponder: () => true` does just that.

You might want to update the web page as well: http://mindthecode.com/getting-started-with-the-panresponder-in-react-native/

Thanks again for writing this. With your help I was able to cross a big "unknown" off my project's list.